### PR TITLE
Update Image Hash Flush

### DIFF
--- a/src/Cropper.php
+++ b/src/Cropper.php
@@ -111,7 +111,7 @@ class Cropper
      */
     protected function hash(string $path): string
     {
-        return hash("crc32", $path);
+        return hash("crc32", pathinfo($path)['basename']);
     }
 
     /**


### PR DESCRIPTION
Essa alteração previne um erro de delete de cache no método "flush()" onde o método "hash()" sempre alterava para um nome diferente e assim não deletava o cache da pasta.