### PR TITLE
Forçando criação de diretórios recursivamente

### DIFF
--- a/src/Cropper.php
+++ b/src/Cropper.php
@@ -49,7 +49,7 @@ class Cropper
         $this->cacheSize = [$jpgQuality, $pngCompressor];
 
         if (!file_exists($this->cachePath) || !is_dir($this->cachePath)) {
-            if (!mkdir($this->cachePath, 0755)) {
+            if (!mkdir($this->cachePath, 0755, true)) {
                 throw new \Exception("Could not create cache folder");
             }
         }


### PR DESCRIPTION
Apesar da função mkdir estar documentada que por default cria diretórios recursivamente, no windows só funcionou após informar o parâmetro manualmente.