### PR TITLE
Adding $exception variable that is missing

### DIFF
--- a/src/Cropper.php
+++ b/src/Cropper.php
@@ -284,7 +284,7 @@ class Cropper
             }
 
             return $webPConverted;
-        } catch (ConversionFailedException) {
+        } catch (ConversionFailedException $exception) {
             return $image;
         }
     }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65863857/161391186-34235c4a-a594-4f94-a8a4-e346c98ae889.png)

In the try...catch block is missing the variable name, containing only the typing ConversionFailedException.
In this PR $exception variable is added.